### PR TITLE
Release antakia-core 0.4.8 — shap>=0.50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "antakia-core"
-version = "0.4.7"
+version = "0.4.8"
 description = "Core modules for AntakIA"
 authors = ["Pierre Hulot <pierre@ai-vidence.com>"]
 readme = "README.md"
@@ -11,7 +11,7 @@ pandas = "^2.2.0"
 scikit-learn = "^1.4.1.post1"
 interpret = "*"
 lime = "^0.2.0.1"
-shap = "^0.43.0"
+shap = ">=0.50.0"
 umap-learn = "^0.5.5"
 skope-rules-temp = ">=0.2.4"
 scipy = "*"


### PR DESCRIPTION
## Summary
- Bump 0.4.8 : contrainte `shap>=0.50.0` (requis par AntakIA 0.5.0 RC6)
- Débloque `pip install antakia==0.5.0` une fois core publié

## Test plan
- [ ] `pip install antakia-core==0.4.8` puis `antakia==0.5.0`

Made with [Cursor](https://cursor.com)